### PR TITLE
 Ignored unused variables in linting. Changed deployment command in docker.

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,4 +21,4 @@ jobs:
                   poetry install
             - name: Lint with black
               run: |
-                  poetry run flake8 --max-line-length 120 --ignore E203,E712,W503 catcord/
+                  poetry run flake8 --max-line-length 120 --ignore E203,E712,W503,F841 catcord/

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -19,6 +19,6 @@ jobs:
               run: |
                   python3 -m pip install poetry
                   poetry install
-            - name: Lint with black
+            - name: Lint with flake8
               run: |
                   poetry run flake8 --max-line-length 120 --ignore E203,E712,W503,F841 catcord/

--- a/catcord/__main__.py
+++ b/catcord/__main__.py
@@ -10,6 +10,7 @@ app = FastAPI()
 async def home():
     return {"message": "Send a POST request to /token to generate a token."}
 
+
 @app.post("/token")
 async def token():
     token = str(uuid4())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "3.9"
 
 services:
-    db:
-        image: postgres
-        volumes:
-            - ./data/db:/var/lib/postgresql/data
-        environment:
-            - POSTGRES_DB=postgres
-            - POSTGRES_USER=postgres
-            - POSTGRES_PASSWORD=postgres
+    # db:
+    #     image: postgres
+    #     volumes:
+    #         - ./data/db:/var/lib/postgresql/data
+    #     environment:
+    #         - POSTGRES_DB=postgres
+    #         - POSTGRES_USER=postgres
+    #         - POSTGRES_PASSWORD=postgres
     web:
         build: .
-        command: uvicorn catcord.__main__:app --host 0.0.0.0
+        command: gunicorn catcord.__main__:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0
         volumes:
             - .:/catcord
         ports:

--- a/poetry.lock
+++ b/poetry.lock
@@ -125,6 +125,20 @@ pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
+name = "gunicorn"
+version = "20.1.0"
+description = "WSGI HTTP Server for UNIX"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "h11"
 version = "0.12.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -317,7 +331,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "135c0eb78becdb1c9c35e6808b1e8a35e5a7c371e5d640da0ba380cc1c59920a"
+content-hash = "2c8cf10b2e574ca4cf70de97bfb0b77418c04a3db54649fce8dd427992ea4722"
 
 [metadata.files]
 appdirs = [
@@ -372,6 +386,10 @@ fastapi = [
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
+gunicorn = [
+    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
 ]
 h11 = [
     {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ black = "^21.6b0"
 uvicorn = "^0.14.0"
 flake8 = "^3.9.2"
 asyncpg = "^0.23.0"
+gunicorn = "^20.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Unused variables are now ignored in flake8 linting. Deployment no longer uses uvicorn, but instead uses gunicorn with uvicorn workers for a more production level deployment environment.