### PR TITLE
Create .gitmessage template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,5 @@
+#<type>[optional scope]: <description>
+
+#[optional body]
+
+#[optional footer(s)]


### PR DESCRIPTION
There are a few ways we can set this up, either everyone individually adds this to their config, or add it to the config:

1. Create .gitmessage file and allow users to configure their own .gitconfig
`git config --global commit.template ~/.gitmessage`
2. Create .gitmessage file and update .gitconfig with adding these lines:
```
...
[commit]
  template = ~/.gitmessage
...
```